### PR TITLE
Multiple extensions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.pytest_cache/
 /.idea/
 /motobox/
+build/
+dist/
+**egg-info/
+**/__pycache__/

--- a/ravioli/ravioli.py
+++ b/ravioli/ravioli.py
@@ -26,6 +26,10 @@ def report_all_functions(filename, args):
         # This is a directory. Run on all the files we can find.
         source_files = list(Path(filename).glob('**/*.c'))
 
+        if args.x:
+            for ext in args.x:
+                source_files += list(Path(filename).glob('**/*.' + str(ext)))
+
         for f in source_files:
             result = run_single_file(str(f))
             if __file_result_is_valid(result):
@@ -85,6 +89,10 @@ def report_ksf_for_all_modules(filename, args):
     else:
         # This is a directory. Run on all the files we can find.
         source_files = list(Path(filename).glob('**/*.c'))
+
+        if args.x is not None:
+            for ext in args.x:
+                source_files += list(Path(filename).glob('**/*.' + str(ext)))
 
         for f in source_files:
             result = run_single_file(str(f))
@@ -165,6 +173,8 @@ def main():
     parser.add_argument('-t', default=0, type=int, metavar='threshold', help='Only display results at or above this '
                                                                              'threshold (KSF or function complexity)')
     parser.add_argument('-e', action='store_true', help='show any errors encountered processing source files')
+    parser.add_argument('-x', action='append', required=False, help='List of file extensions to search for')
+
     args = parser.parse_args()
     run(args.source, args)
 

--- a/ravioli/ravioli.py
+++ b/ravioli/ravioli.py
@@ -24,11 +24,7 @@ def report_all_functions(filename, args):
         results.append(run_single_file(filename))
     else:
         # This is a directory. Run on all the files we can find.
-        source_files = list(Path(filename).glob('**/*.c'))
-
-        if args.x:
-            for ext in args.x:
-                source_files += list(Path(filename).glob('**/*.' + str(ext)))
+        source_files = get_source_files(args)
 
         for f in source_files:
             result = run_single_file(str(f))
@@ -88,11 +84,7 @@ def report_ksf_for_all_modules(filename, args):
         results.append(run_single_file(filename))
     else:
         # This is a directory. Run on all the files we can find.
-        source_files = list(Path(filename).glob('**/*.c'))
-
-        if args.x is not None:
-            for ext in args.x:
-                source_files += list(Path(filename).glob('**/*.' + str(ext)))
+        source_files = get_source_files(args)
 
         for f in source_files:
             result = run_single_file(str(f))
@@ -164,6 +156,15 @@ def find_max_complexity(functions):
     return max_scc
 
 
+def get_source_files(args):
+    source_files = list(Path(args.source).glob('**/*.c'))
+    if args.x is not None:
+        source_files = []
+        for ext in args.x:
+            source_files += list(Path(args.source).glob('**/*.' + str(ext)))
+    return source_files
+
+
 def main():
     parser = argparse.ArgumentParser(description='Calculate complexity metrics for C code, specifically the Koopman '
                                                  'Spaghetti Factor (KSF).')
@@ -173,7 +174,7 @@ def main():
     parser.add_argument('-t', default=0, type=int, metavar='threshold', help='Only display results at or above this '
                                                                              'threshold (KSF or function complexity)')
     parser.add_argument('-e', action='store_true', help='show any errors encountered processing source files')
-    parser.add_argument('-x', action='append', required=False, help='List of file extensions to search for')
+    parser.add_argument('-x', action='append', required=False, help='File extensions to include in the analysis (-x c -x cc -x h ...). If omitted, only .c files are analyzed')
 
     args = parser.parse_args()
     run(args.source, args)


### PR DESCRIPTION
Hi, I've just added support for use additional extensions using `-x` argument. Currently, it is used in append mode:

`ravioli [-h] [-f] [-t threshold] [-e] [[-x h] [-x cc] ...] source `

However, it could be implemented as a list but should be after the source:

`ravioli [-h] [-f] [-t threshold] [-e] source [-x h cc ...]`

Please let me know if the project is open to PRs and which option do you think it is better for the implementation. I will update the help and readme afterwards. Thanks.