### PR TITLE
Fix finding globals with initializer lists

### DIFF
--- a/ravioli/global_finder.py
+++ b/ravioli/global_finder.py
@@ -14,7 +14,7 @@ def find_globals(code):
     if "some_const_array" in code:
         print(code)
     # Remove anything between brackets.
-    code = re.sub(r'{.*}', '{}', code, flags=re.DOTALL)
+    code = re.sub(r'{[^}]*}', '{}', code, flags=re.DOTALL)
     # Find all the globals.
     global_matcher = re.compile(r'([\w\t\f\v {}]+)\s+(\w+)[\d\[\]]*(?:;|\s*=)')
     for m in global_matcher.finditer(code):
@@ -46,3 +46,5 @@ def __strip_preprocessor_directives(code):
     non_pound_defines = [line for line in code_lines if not line.lstrip().startswith("#")]
     code = "".join(non_pound_defines)
     return code
+
+

--- a/ravioli/global_finder.py
+++ b/ravioli/global_finder.py
@@ -11,6 +11,8 @@ def find_globals(code):
     code = strip_comments(code)
     # Remove #ifs, #elifs, #ifdefs
     code = __strip_preprocessor_directives(code)
+    if "some_const_array" in code:
+        print(code)
     # Remove anything between brackets.
     code = re.sub(r'{.*}', '{}', code, flags=re.DOTALL)
     # Find all the globals.

--- a/test/c/initialized_array.c
+++ b/test/c/initialized_array.c
@@ -1,0 +1,4 @@
+u8 factoryCode[4] = {0,1,1,2};
+u64 test1;
+u64 test2;
+

--- a/test/c/initialized_array.c
+++ b/test/c/initialized_array.c
@@ -1,4 +1,7 @@
+/**
+ * This is a file that defines globals after an initialized global array.
+ */
+
 u8 factoryCode[4] = {0,1,1,2};
 u64 test1;
 u64 test2;
-

--- a/test/test_command_line.py
+++ b/test/test_command_line.py
@@ -51,3 +51,11 @@ def test_x_option_with_multiple_extensions():
     assert ("sample.c" in stdout)
     assert ("main.c" in stdout)
     assert ("another_file.cpp" in stdout)
+
+
+def test_find_globals_after_initialized_array_in_file():
+    sys.argv = ["ravioli", "c/initialized_array.c", "-f"]
+    stdout = run_ravioli()
+    assert ("initialized_array.c:1 factoryCode" in stdout)
+    assert ("initialized_array.c:2 test1" in stdout)
+    assert ("initialized_array.c:3 test2" in stdout)

--- a/test/test_command_line.py
+++ b/test/test_command_line.py
@@ -56,6 +56,6 @@ def test_x_option_with_multiple_extensions():
 def test_find_globals_after_initialized_array_in_file():
     sys.argv = ["ravioli", "c/initialized_array.c", "-f"]
     stdout = run_ravioli()
-    assert ("initialized_array.c:1 factoryCode" in stdout)
-    assert ("initialized_array.c:2 test1" in stdout)
-    assert ("initialized_array.c:3 test2" in stdout)
+    assert ("initialized_array.c:5 factoryCode" in stdout)
+    assert ("initialized_array.c:6 test1" in stdout)
+    assert ("initialized_array.c:7 test2" in stdout)

--- a/test/test_global_finder.py
+++ b/test/test_global_finder.py
@@ -268,3 +268,13 @@ def test_find_globals_after_initialized_array():
     assert ('factoryCode' in extract_names(results))
     assert ('test1' in extract_names(results))
     assert ('test2' in extract_names(results))
+
+
+def test_find_initialized_array_after_const_array():
+
+    code = """
+        const u8 some_const_array[4] = {1,2,3,4};
+        u8 factoryCode[4] = {0,1,1,2};
+        """
+    results = find_globals(code)
+    assert ('factoryCode' in extract_names(results))

--- a/test/test_global_finder.py
+++ b/test/test_global_finder.py
@@ -273,8 +273,9 @@ def test_find_globals_after_initialized_array():
 def test_find_initialized_array_after_const_array():
 
     code = """
-        const u8 some_const_array[4] = {1,2,3,4};
-        u8 factoryCode[4] = {0,1,1,2};
+        u8 array1[4] = {1,2,3,4};
+        u8 array2[4] = {5,6,7,8};
         """
     results = find_globals(code)
-    assert ('factoryCode' in extract_names(results))
+    assert ('array1' in extract_names(results))
+    assert ('array2' in extract_names(results))

--- a/test/test_global_finder.py
+++ b/test/test_global_finder.py
@@ -256,3 +256,15 @@ def test_line_number_with_a_declaration_as_part_of_a_definition():
     results = find_globals(code)
     assert (4 == results[0].line_number)
 
+
+def test_find_globals_after_initialized_array():
+    code = """
+        u8 factoryCode[4] = {0,1,1,2};
+        u64 test1;
+        u64 test2;
+        """
+    results = find_globals(code)
+
+    assert ('factoryCode' in extract_names(results))
+    assert ('test1' in extract_names(results))
+    assert ('test2' in extract_names(results))

--- a/test/test_global_finder.py
+++ b/test/test_global_finder.py
@@ -279,3 +279,21 @@ def test_find_initialized_array_after_const_array():
     results = find_globals(code)
     assert ('array1' in extract_names(results))
     assert ('array2' in extract_names(results))
+
+
+def test_handle_array_of_structs_initialization():
+
+    code = """
+        u8 array1[4] = {1,2,3,4};
+        data_t array_of_structs[]={
+            { .name = "Peter" },
+            { .name = "James" },
+            { .name = "John" },
+            { .name = "Mike" }
+        };
+        u8 array2[4] = {5,6,7,8};
+        """
+    results = find_globals(code)
+    assert ('array1' in extract_names(results))
+    assert ('array2' in extract_names(results))
+    assert ('array_of_structs' in extract_names(results))


### PR DESCRIPTION
The handling of initializer lists (enclosed in curly brackets) wasn't working correctly.

I think this should fix #3.